### PR TITLE
Improve CORS origins configuration with flexible parsing

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -66,7 +66,7 @@ app = FastAPI(
 # CORS設定
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.cors_origins,
+    allow_origins=settings.backend_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
Enhanced CORS origins configuration to support multiple input formats (JSON list, comma-separated string, or Python list) with automatic normalization. Renamed the configuration variable from `cors_origins` to `backend_cors_origins` for clarity.

## Key Changes
- Renamed `cors_origins` to `backend_cors_origins` in Settings class for better naming convention
- Added `@field_validator` to `backend_cors_origins` that intelligently parses multiple input formats:
  - JSON array format: `'["http://localhost:3000", "https://example.com"]'`
  - Comma-separated format: `"http://localhost:3000,https://example.com"`
  - Python list format: `["http://localhost:3000", "https://example.com"]`
- Automatically normalizes all origins by stripping whitespace and trailing slashes
- Updated CORS middleware configuration to use the renamed setting

## Implementation Details
- The validator uses `mode="before"` to process raw input values before Pydantic's standard validation
- Gracefully falls back from JSON parsing to comma-separated parsing if JSON parsing fails
- Ensures consistent origin formatting regardless of input method, improving reliability and reducing configuration errors
- This change makes the configuration more flexible for different deployment scenarios (environment variables, config files, etc.)

https://claude.ai/code/session_01V5nFbqQoiMESUVRUg5y26g