### PR TITLE
Add Do/Talk mode switching and Layer 3 collective wisdom integration

### DIFF
--- a/backend/alembic/versions/20260211_add_state_to_logintent_enum.py
+++ b/backend/alembic/versions/20260211_add_state_to_logintent_enum.py
@@ -1,0 +1,24 @@
+"""add STATE value to logintent enum
+
+Revision ID: 20260211_state
+Revises: 20260208_thread
+Create Date: 2026-02-11
+
+"""
+from alembic import op
+
+
+revision = "20260211_state"
+down_revision = "20260208_thread"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # PostgreSQL の ENUM に新しい値を追加
+    op.execute("ALTER TYPE logintent ADD VALUE IF NOT EXISTS 'STATE'")
+
+
+def downgrade() -> None:
+    # PostgreSQL の ENUM から値を削除するのは困難なため、ダウングレードは非対応
+    pass

--- a/backend/app/api/v1/endpoints/logs.py
+++ b/backend/app/api/v1/endpoints/logs.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Optional
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status, UploadFile, File
+from fastapi import APIRouter, Depends, Form, HTTPException, Query, status, UploadFile, File
 from sqlalchemy import select, func, desc, and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from openai import AsyncOpenAI
@@ -151,8 +151,12 @@ async def create_log(
 
     # Deep Research 実行時は会話エージェントをスキップ（既に返答が決まっている）
     if conversation_reply is None:
-        # 同一スレッド内の直前の構造的課題を取得（Situation Router 用）
+        # 直前の構造的課題を取得（Situation Router 用）
+        # 1. 同一スレッド内を探す → 2. なければスレッド横断で直近ログを参照
         previous_topic = None
+        prev_log = None
+
+        # ── 1. 同一スレッド内 ──
         if log.thread_id:
             prev_result = await session.execute(
                 select(RawLog)
@@ -165,11 +169,25 @@ async def create_log(
                 .limit(1)
             )
             prev_log = prev_result.scalar_one_or_none()
-            if prev_log and prev_log.structural_analysis:
-                previous_topic = (
-                    prev_log.structural_analysis.get("updated_structural_issue")
-                    or prev_log.structural_analysis.get("structural_issue")
+
+        # ── 2. フォールバック: スレッド横断で直近ログ ──
+        if prev_log is None:
+            fallback_result = await session.execute(
+                select(RawLog)
+                .where(
+                    RawLog.user_id == current_user.id,
+                    RawLog.id != log.id,
                 )
+                .order_by(desc(RawLog.created_at))
+                .limit(1)
+            )
+            prev_log = fallback_result.scalar_one_or_none()
+
+        if prev_log and prev_log.structural_analysis:
+            previous_topic = (
+                prev_log.structural_analysis.get("updated_structural_issue")
+                or prev_log.structural_analysis.get("structural_issue")
+            )
 
         # 状況をコードで分類し、会話エージェントに渡す
         situation = situation_router.classify(log_in.content, previous_topic)
@@ -192,6 +210,7 @@ async def create_log(
     # 受容的な相槌を返す
     return AckResponse.create_ack(
         log_id=log.id,
+        thread_id=log.thread_id,
         intent=log.intent,
         emotions=log.emotions,
         content=log.content,
@@ -325,6 +344,7 @@ async def get_logs_by_month(
 @router.post("/transcribe", response_model=AckResponse, status_code=status.HTTP_201_CREATED)
 async def transcribe_audio(
     audio: UploadFile = File(...),
+    thread_id: Optional[str] = Form(None),
     session: AsyncSession = Depends(get_async_session),
     current_user: User = Depends(get_current_user),
 ):
@@ -373,12 +393,13 @@ async def transcribe_audio(
                 detail="音声を認識できませんでした。もう一度お試しください。",
             )
 
-        # ログの作成（音声は新規スレッド）
+        # ログの作成（thread_id が指定されていれば同一スレッドに継続）
+        parsed_thread_id = uuid.UUID(thread_id) if thread_id else None
         log = RawLog(
             user_id=current_user.id,
             content=transcribed_text,
             content_type="voice",
-            thread_id=None,
+            thread_id=parsed_thread_id,
         )
         session.add(log)
         await session.commit()
@@ -434,6 +455,7 @@ async def transcribe_audio(
 
         return AckResponse.create_ack(
             log_id=log.id,
+            thread_id=log.thread_id,
             intent=log.intent,
             emotions=log.emotions,
             content=log.content,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -104,7 +104,7 @@ class Settings(BaseSettings):
     celery_result_backend: str = Field(default="redis://localhost:6379/2")
 
     # Layer 2 Processing
-    sharing_threshold_score: int = 70  # 共有価値スコアの閾値
+    sharing_threshold_score: int = 80  # 「推奨」の閾値（この値以上で共有を推奨、未満は通常）
     system_bot_user_id: str = "00000000-0000-0000-0000-000000000001"
 
     # CORS

--- a/backend/app/models/insight.py
+++ b/backend/app/models/insight.py
@@ -30,8 +30,8 @@ if TYPE_CHECKING:
 class InsightStatus(str, Enum):
     """インサイトの状態"""
 
-    DRAFT = "draft"  # 生成直後、ユーザー確認待ち
-    PENDING_APPROVAL = "pending_approval"  # 共有提案中
+    DRAFT = "draft"  # 通常（スコア80未満、保存のみ）
+    PENDING_APPROVAL = "pending_approval"  # 推奨（スコア80以上、ユーザーに共有を提案）
     APPROVED = "approved"  # 承認済み、公開
     REJECTED = "rejected"  # ユーザーが拒否
 

--- a/backend/app/schemas/raw_log.py
+++ b/backend/app/schemas/raw_log.py
@@ -70,6 +70,7 @@ class AckResponse(BaseModel):
 
     message: str
     log_id: uuid.UUID
+    thread_id: uuid.UUID  # スレッドID（フロントが次の送信で使う）
     timestamp: datetime
     transcribed_text: Optional[str] = None  # 音声入力時の文字起こしテキスト
     skip_structural_analysis: bool = False
@@ -81,6 +82,7 @@ class AckResponse(BaseModel):
     def create_ack(
         cls,
         log_id: uuid.UUID,
+        thread_id: Optional[uuid.UUID] = None,
         intent: Optional[LogIntent] = None,
         emotions: Optional[List[str]] = None,
         content: Optional[str] = None,
@@ -104,6 +106,7 @@ class AckResponse(BaseModel):
             return cls(
                 message=state_message,
                 log_id=log_id,
+                thread_id=thread_id or log_id,
                 timestamp=datetime.now(),
                 transcribed_text=transcribed_text,
                 skip_structural_analysis=True,
@@ -141,6 +144,7 @@ class AckResponse(BaseModel):
         return cls(
             message=message,
             log_id=log_id,
+            thread_id=thread_id or log_id,
             timestamp=datetime.now(),
             transcribed_text=transcribed_text,
             skip_structural_analysis=skip_analysis,

--- a/backend/app/services/layer1/conversation_agent.py
+++ b/backend/app/services/layer1/conversation_agent.py
@@ -4,9 +4,12 @@ Layer 1: 自然な人間らしい会話返答を生成する
 
 ai-agent-playground-101 方式: シンプルなプロンプト + 会話履歴 → 自然な応答
 ルールは最小限にし、LLM の自然な対話能力に任せる。
+
+Layer 3 連携: 会話中にQdrant（みんなの知恵）を検索し、
+関連するインサイトがあれば自然な会話の中で言及する。
 """
 import logging
-from typing import Optional, List, Tuple, TYPE_CHECKING
+from typing import Optional, List, Tuple, Dict, TYPE_CHECKING
 
 from sqlalchemy import select, desc
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -14,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.llm import llm_manager
 from app.core.llm_provider import LLMProvider, LLMUsageRole
 from app.models.raw_log import RawLog
+from app.services.layer3.knowledge_store import knowledge_store
 
 if TYPE_CHECKING:
     from app.services.layer1.situation_router import SituationResult
@@ -23,11 +27,10 @@ logger = logging.getLogger(__name__)
 # スレッド内の履歴を多めに取得（会話の流れを把握する）
 CONVERSATION_HISTORY_LIMIT = 10
 
-# ────────────────────────────────────────
-# 知的好奇心旺盛な思考パートナーのプロンプト
-# 「聞くだけ」ではなく「一緒に考える」存在として設計
-# ────────────────────────────────────────
-_CONVERSATION_SYSTEM_PROMPT = """\
+# ════════════════════════════════════════
+# Talk モード: 思考パートナー（対話・共感・整理）
+# ════════════════════════════════════════
+_TALK_SYSTEM_PROMPT = """\
 あなたは知的好奇心旺盛な「思考パートナー」です。
 相手の話に真剣に向き合い、自分の知識も活かしながら対話します。
 
@@ -74,8 +77,94 @@ _CONVERSATION_SYSTEM_PROMPT = """\
   入力「新しいプロジェクトを任された」
   →「おめでとうございます。任されるということは期待の表れですね。今の段階で一番気になっているのは、技術的な部分ですか？それともチーム編成や進め方の部分ですか？」
 
+## みんなの知恵（チームの過去の知見）が提供された場合
+- システムメッセージに【みんなの知恵】セクションが含まれることがある。
+- その場合、会話の流れに自然に溶け込む形で**さりげなく言及**する。
+- 「似た経験をした方がいて〜」「チーム内でこんな知見があるのですが〜」のように、
+  押し付けず、会話の中で自然に共有する。具体的な内容（解決策やポイント）を含めること。
+- 関連度が低い場合や会話の流れに合わない場合は無理に言及しない。
+- 「誰が」とは言わない（匿名）。
+
 ## 文体
 です・ます調。知的で親しみやすく、対等な立場で。"""
+
+
+# ════════════════════════════════════════
+# Do モード: 実行パートナー（結論→手順→コード→罠）
+# ════════════════════════════════════════
+_DO_SYSTEM_PROMPT = """\
+あなたは優秀な「実行パートナー」です。
+相手が求めているのは共感ではなく**具体的な成果物**です。
+会話履歴の文脈を踏まえ、即座に実行可能な回答を出してください。
+
+## 応答フォーマット（必ずこの順序で）
+
+**1. 結論（1〜2行）**
+何をすべきか / 答えは何か を最初に明示。
+
+**2. 手順（番号付き）**
+すぐ実行できるステップを具体的に。抽象的な「検討する」は禁止。
+
+**3. すぐ動く最小コード or コマンド**（該当する場合）
+コピペで動くものを出す。「イメージとしては〜」のような曖昧な擬似コードは禁止。
+技術的な話でない場合はこのセクションを省略してよい。
+
+**4. 失敗しがちな罠と確認方法**
+初心者がハマりやすいポイントを1〜2個。
+「〜に注意してください」ではなく「〜を確認: コマンド/チェック方法」の形で。
+
+## 核心ルール
+1. **聞き返し禁止**: 会話履歴に十分な情報があるなら、聞き返さず即答する。
+2. **結論ファースト**: 前置き（「いいですね！」「了解です！」等）は1文以内。すぐ本題に入る。
+3. **具体性100%**: 技術名・ツール名・バージョン・コマンドは省略せず書く。
+4. 会話履歴に計画・設計・仕様があるなら、それを**そのまま活かして**回答する。
+   勝手に別の方針に変えない。
+5. 情報が足りないときだけ、「AとBどちらにしますか？」のように**選択肢付き**で1回だけ聞く。
+
+## 絶対禁止
+- 「何を作成しますか？」「もう少し教えてください」（履歴に情報があるのに聞く）
+- 「〜は重要ですね」「〜を検討しましょう」だけで手を動かさない
+- 共感だけの応答（「素晴らしい計画ですね！」で終わる）
+- 抽象的なアドバイス（「テストを書きましょう」→ 具体的なテストコードを出す）
+
+## 良い応答と悪い応答の具体例
+
+悪い例:
+  履歴「Next.js + Supabase でSNSを作る計画を立てた」
+  入力「作成せよ」
+  →「具体的に何を作成しますか？」
+  （履歴に全部書いてある。聞き返しは最悪の応答）
+
+良い例:
+  履歴「Next.js + Supabase でSNSを作る計画を立てた」
+  入力「作成せよ」
+  →「了解。まず最小構成で動かします。
+
+  1. プロジェクト作成
+  ```
+  npx create-next-app@latest agent-sns --ts --tailwind --app
+  cd agent-sns && npm i @supabase/supabase-js
+  ```
+
+  2. Supabase テーブル作成（SQL）
+  ```sql
+  create table profiles ( ... );
+  create table posts ( ... );
+  ```
+
+  ⚠️ 罠: Supabase の RLS を忘れると全データ公開になる。
+  確認: Supabase ダッシュボード → Authentication → Policies で各テーブルにポリシーがあるか確認。」
+
+## みんなの知恵（チームの過去の知見）が提供された場合
+- システムメッセージに【みんなの知恵】セクションが含まれることがある。
+- その場合、回答の手順やコード例に**チームの実績として具体的に組み込む**。
+- 「チーム内で以前〜で成功した実績があります」のように根拠として使う。
+- 知見の解決策やポイントが使える場合は、手順の中で積極的に引用する。
+- 関連度が低い場合は無理に言及しない。
+- 「誰が」とは言わない（匿名）。
+
+## 文体
+です・ます調。簡潔で的確。余計な前置き・感想は最小限に。"""
 
 
 class ConversationAgent:
@@ -108,6 +197,9 @@ class ConversationAgent:
         """
         会話履歴と新しい発話をまとめて LLM に送り、自然な返答を得る。
         ai-agent-playground-101 方式: 履歴 + 発話 → LLM → 返答。シンプル。
+
+        Layer 3 連携: ユーザーの入力で Qdrant を検索し、
+        関連インサイトがあればシステムプロンプトに注入する。
         """
         provider = self._get_provider()
         if not provider:
@@ -118,7 +210,14 @@ class ConversationAgent:
             session, user_id, new_log.id,
             thread_id=getattr(new_log, "thread_id", None),
         )
-        messages = self._build_messages(new_log.content, history, situation)
+
+        # ── Layer 3: みんなの知恵を検索 ──
+        related_insights = await self._search_collective_wisdom(new_log.content)
+
+        messages = self._build_messages(
+            new_log.content, history, situation,
+            related_insights=related_insights,
+        )
 
         try:
             await provider.initialize()
@@ -162,10 +261,32 @@ class ConversationAgent:
         thread_id: Optional[object] = None,
     ) -> List[Tuple[str, Optional[str]]]:
         """
-        同一スレッドの会話履歴を時系列で取得する。
+        会話履歴を時系列で取得する。
+        1. まず同一スレッド内の履歴を探す。
+        2. スレッド内に履歴がなければ（新規スレッド）、ユーザーの
+           直近ログをスレッド横断で取得する（文脈を失わないため）。
         各ログの (user_content, assistant_reply) のペアを返す。
         """
-        q = (
+        # ── 1. 同一スレッド内の履歴 ──
+        if thread_id is not None:
+            q_thread = (
+                select(RawLog)
+                .where(
+                    RawLog.user_id == user_id,
+                    RawLog.thread_id == thread_id,
+                    RawLog.id != exclude_log_id,
+                )
+                .order_by(desc(RawLog.created_at))
+                .limit(CONVERSATION_HISTORY_LIMIT)
+            )
+            result = await session.execute(q_thread)
+            logs = list(result.scalars().all())
+            if logs:
+                logs.reverse()
+                return [(log.content, log.assistant_reply) for log in logs]
+
+        # ── 2. フォールバック: スレッド横断で直近ログを取得 ──
+        q_global = (
             select(RawLog)
             .where(
                 RawLog.user_id == user_id,
@@ -174,11 +295,9 @@ class ConversationAgent:
             .order_by(desc(RawLog.created_at))
             .limit(CONVERSATION_HISTORY_LIMIT)
         )
-        if thread_id is not None:
-            q = q.where(RawLog.thread_id == thread_id)
-        result = await session.execute(q)
+        result = await session.execute(q_global)
         logs = list(result.scalars().all())
-        logs.reverse()  # 時系列順にする
+        logs.reverse()
         return [(log.content, log.assistant_reply) for log in logs]
 
     def _build_messages(
@@ -186,21 +305,48 @@ class ConversationAgent:
         new_content: str,
         history: List[Tuple[str, Optional[str]]],
         situation: Optional["SituationResult"] = None,
+        related_insights: Optional[List[Dict]] = None,
     ) -> List[dict]:
         """
         LLM に送るメッセージ配列を構築する。
         ai-agent-playground-101 方式: system + 過去のやり取り + 今回の発話。
         SituationRouter の結果はシステムプロンプトに短いヒントとして追加し、
         ユーザー発話は一切改変しない（自然さを保つため）。
+
+        短い発話（命令形など）+ 履歴がある場合は、直近ログの要約を
+        システムプロンプトに注入して LLM が文脈を確実に把握できるようにする。
+
+        Layer 3 連携: related_insights が渡された場合、
+        「みんなの知恵」としてシステムプロンプトに注入する。
         """
-        # システムプロンプト
-        system_prompt = _CONVERSATION_SYSTEM_PROMPT
+        # ── Do / Talk モード切り替え ──
+        is_do = situation.do_mode if situation else False
+        system_prompt = _DO_SYSTEM_PROMPT if is_do else _TALK_SYSTEM_PROMPT
 
         # 状況ヒントをシステムプロンプト末尾に追加（ユーザー発話には触れない）
         if situation and situation.situation_type != "generic":
             hint = self._situation_hint(situation)
             if hint:
                 system_prompt += f"\n\n【今回の状況ヒント】\n{hint}"
+
+        # ── 短い発話 + 履歴あり → 直近の会話コンテキストを明示的に要約して注入 ──
+        is_short_utterance = len(new_content.strip()) <= 30
+        if is_short_utterance and history:
+            context_summary = self._summarize_recent_context(history)
+            if context_summary:
+                system_prompt += (
+                    f"\n\n【直近の会話コンテキスト（重要）】\n"
+                    f"ユーザーの発話が短いため、直前の会話内容を以下に要約します。"
+                    f"この文脈を踏まえて応答してください。"
+                    f"「何についてですか？」のような聞き返しは禁止。\n\n"
+                    f"{context_summary}"
+                )
+
+        # ── Layer 3: みんなの知恵を注入 ──
+        if related_insights:
+            wisdom_text = self._format_collective_wisdom(related_insights)
+            if wisdom_text:
+                system_prompt += f"\n\n{wisdom_text}"
 
         messages: List[dict] = [{"role": "system", "content": system_prompt}]
 
@@ -213,6 +359,42 @@ class ConversationAgent:
         # 今回のユーザー発話（改変しない）
         messages.append({"role": "user", "content": new_content})
         return messages
+
+    @staticmethod
+    def _summarize_recent_context(
+        history: List[Tuple[str, Optional[str]]],
+        max_chars: int = 1500,
+    ) -> Optional[str]:
+        """
+        直近の会話履歴から要約テキストを生成する。
+        LLM を使わず、直近のユーザー発話を連結して文脈として提供する。
+        長い発話は冒頭を切り出し、全体で max_chars に収める。
+        """
+        if not history:
+            return None
+
+        parts: List[str] = []
+        total = 0
+        # 新しい方から辿り、最大 max_chars 分を収集
+        for user_content, assistant_reply in reversed(history):
+            snippet = user_content.strip()
+            if len(snippet) > 400:
+                snippet = snippet[:400] + "…（省略）"
+            entry = f"- ユーザー: {snippet}"
+            if assistant_reply:
+                reply_snippet = assistant_reply.strip()
+                if len(reply_snippet) > 200:
+                    reply_snippet = reply_snippet[:200] + "…"
+                entry += f"\n  AI: {reply_snippet}"
+            if total + len(entry) > max_chars:
+                break
+            parts.append(entry)
+            total += len(entry)
+
+        if not parts:
+            return None
+        parts.reverse()
+        return "\n".join(parts)
 
     @staticmethod
     def _situation_hint(situation: "SituationResult") -> Optional[str]:
@@ -228,6 +410,14 @@ class ConversationAgent:
                 f"相手は前の話題の「続き」を希望しています。"
                 f"履歴にある話題の具体的な内容を踏まえて、前回の会話を発展させてください。"
                 f"「その続きですね」のような薄い返答は禁止。前回の具体的な論点に言及すること。"
+            )
+        elif st == "imperative":
+            return (
+                f"相手は「{topic}」に関して行動・実行を指示しています。"
+                f"履歴に具体的な計画や内容があるはずです。それを踏まえて、"
+                f"次の具体的なアクションステップを提示してください。"
+                f"「何を作成しますか？」のような聞き返しは絶対に禁止。"
+                f"履歴の文脈から何をすべきかは明らかなので、すぐに実行に移る返答をすること。"
             )
         elif st == "correction":
             return (
@@ -256,6 +446,92 @@ class ConversationAgent:
                 f"前回の会話内容を踏まえて、まだ掘り下げていない角度から話を広げてください。"
             )
         return None
+
+    # ════════════════════════════════════════
+    # Layer 3 連携: みんなの知恵
+    # ════════════════════════════════════════
+
+    async def _search_collective_wisdom(
+        self,
+        user_content: str,
+        limit: int = 3,
+        score_threshold: float = 0.70,
+    ) -> List[Dict]:
+        """
+        ユーザーの入力を使って Qdrant（みんなの知恵）を検索する。
+        関連度が高く、かつ品質が十分なインサイトだけを返す。
+        """
+        # 短すぎる入力では検索しない（ノイズ回避）
+        if len(user_content.strip()) < 10:
+            return []
+
+        try:
+            # 品質フィルタ後に limit 個になるよう、多めに取得
+            results = await knowledge_store.search_similar(
+                query=user_content,
+                limit=limit * 2,
+                score_threshold=score_threshold,
+            )
+
+            # ── 品質フィルタ: 中身が薄いインサイトを除外 ──
+            filtered = []
+            for ins in results:
+                summary = (ins.get("summary") or "").strip()
+                solution = (ins.get("solution") or "").strip()
+                title = (ins.get("title") or "").strip()
+
+                # 要約もしくは解決策に実質的な内容がないものは除外
+                if len(summary) < 20 and len(solution) < 20:
+                    logger.debug(
+                        "Collective wisdom: filtered out low-quality insight: %s",
+                        title,
+                    )
+                    continue
+                filtered.append(ins)
+                if len(filtered) >= limit:
+                    break
+
+            if filtered:
+                logger.info(
+                    "Collective wisdom: found %d/%d insights (after quality filter) for: %.30s...",
+                    len(filtered), len(results), user_content,
+                )
+            return filtered
+        except Exception as e:
+            logger.debug("Collective wisdom search failed (non-critical): %s", e)
+            return []
+
+    @staticmethod
+    def _format_collective_wisdom(insights: List[Dict]) -> Optional[str]:
+        """
+        検索結果を LLM のシステムプロンプトに注入する形式にフォーマットする。
+        """
+        if not insights:
+            return None
+
+        lines = [
+            "【みんなの知恵 — チーム内の過去の知見】",
+            "以下はユーザーの話題に関連する、チーム内の匿名化された知見です。",
+            "会話に自然に溶け込む形でさりげなく共有してください。",
+            "押し付けず、関連する場合のみ言及すること。\n",
+        ]
+        for i, ins in enumerate(insights, 1):
+            title = ins.get("title", "（タイトルなし）")
+            summary = ins.get("summary", "")
+            topics = ", ".join(ins.get("topics", []))
+            score = round(ins.get("score", 0) * 100)
+
+            lines.append(f"  {i}. 「{title}」（関連度 {score}%）")
+            if summary:
+                # 長すぎるサマリーは切り詰め
+                if len(summary) > 200:
+                    summary = summary[:200] + "…"
+                lines.append(f"     要約: {summary}")
+            if topics:
+                lines.append(f"     トピック: {topics}")
+            lines.append("")
+
+        return "\n".join(lines)
 
     @staticmethod
     def _guess_topic(

--- a/backend/app/services/layer1/situation_router.py
+++ b/backend/app/services/layer1/situation_router.py
@@ -12,8 +12,9 @@ from typing import Optional
 @dataclass
 class SituationResult:
     """状況分類の結果"""
-    situation_type: str  # continuation, same_topic_short, topic_switch, criticism_then_topic, vent, question, generic
+    situation_type: str  # continuation, imperative, same_topic_short, topic_switch, criticism_then_topic, vent, question, generic
     resolved_topic: Optional[str] = None  # 会話で触れるべきテーマ（前の課題 or 抽出した本題）
+    do_mode: bool = False  # True = 実行・結論指向（Do）, False = 対話・共感指向（Talk）
 
 
 # 続き希望の表現（「続ける」「続けて」も短いときは続き希望）
@@ -92,6 +93,71 @@ def _is_collaborative_or_rejecting_problem(text: str) -> bool:
     return any(p in t for p in phrases)
 
 
+def _is_imperative_command(text: str) -> bool:
+    """「作成せよ」「やれ」「実行して」など、前の話題に対する命令・指示"""
+    t = text.replace("\n", " ").strip()
+    if not t or len(t) > 60:
+        return False
+    # 「〜せよ」「〜しろ」「〜して」「〜やって」「〜やれ」「〜始めろ」「〜お願い」 など
+    imperative_endings = (
+        "せよ", "しろ", "して", "してくれ", "してください",
+        "やれ", "やって", "やってくれ", "やってください",
+        "始めろ", "始めて", "始めてくれ", "始めてください",
+        "作れ", "作って", "作ってくれ", "作ってください",
+        "実行して", "実行しろ", "実行せよ",
+        "お願い", "お願いします", "頼む", "頼んだ",
+        "進めて", "進めろ", "進めてくれ",
+    )
+    return any(t.endswith(e) for e in imperative_endings)
+
+
+def _is_do_intent(text: str) -> bool:
+    """
+    Do モード判定: 結論・手順・実装・比較・設計など、具体的な成果物を求める発話。
+    「〜して」「作って」「直して」「実装」「比較」「設計」「書いて」「教えて（方法）」等。
+    """
+    t = text.replace("\n", " ").strip()
+    if not t:
+        return False
+
+    # 明確な実行指示の語尾
+    do_endings = (
+        "せよ", "しろ", "して", "してくれ", "してください",
+        "やれ", "やって", "やってくれ", "やってください",
+        "始めろ", "始めて", "始めてくれ", "始めてください",
+        "作れ", "作って", "作ってくれ", "作ってください",
+        "実行して", "実行しろ", "実行せよ",
+        "進めて", "進めろ", "進めてくれ",
+        "書いて", "書いてくれ", "書いてください",
+        "直して", "直してくれ", "直してください",
+        "調べて", "調べてくれ", "調べてください",
+        "出して", "出してくれ", "出してください",
+        "まとめて", "まとめてくれ", "まとめてください",
+        "整理して", "整理してくれ", "整理してください",
+    )
+    if any(t.endswith(e) for e in do_endings):
+        return True
+
+    # 実行指向キーワード（文中のどこかに含まれる）
+    do_keywords = (
+        "実装", "コーディング", "設計", "比較", "リファクタ",
+        "デプロイ", "テスト", "デバッグ", "手順", "方法",
+        "ステップ", "コマンド", "スクリプト", "SQL", "API",
+        "コードを", "プログラムを", "アプリを", "サービスを",
+        "作成する", "構築する", "開発する", "修正する",
+        "書き出し", "メリット", "デメリット", "リスト",
+        "計画を", "設計を", "仕様を", "要件を",
+    )
+    if any(kw in t for kw in do_keywords):
+        return True
+
+    # 「〇〇を作成」「〇〇を実装」パターン
+    if re.search(r"を\s*(作成|実装|構築|開発|設計|修正|作る|書く|出す)", t):
+        return True
+
+    return False
+
+
 def _is_correction_or_clarification(text: str) -> bool:
     """「〇〇は関係ない」「違う」「そうじゃない」など、直前の問いへの訂正・補足"""
     t = text.replace("\n", " ").strip()
@@ -114,14 +180,27 @@ class SituationRouter:
     ) -> SituationResult:
         """
         発話内容と前の話題から状況を分類する。
+        do_mode: 実行・結論指向（Do）かどうかを判定し、フラグに設定。
         previous_topic: 同一スレッドの直前の構造的課題（あれば）
         """
         text = (content or "").strip()
+
+        # ── Do / Talk モード判定（全分岐共通で使う） ──
+        do = _is_do_intent(text)
 
         if _is_continuation(text):
             return SituationResult(
                 situation_type="continuation",
                 resolved_topic=previous_topic,
+                do_mode=do,
+            )
+
+        # 「作成せよ」「やれ」など命令形 → 前の話題の実行指示
+        if _is_imperative_command(text) and previous_topic:
+            return SituationResult(
+                situation_type="imperative",
+                resolved_topic=previous_topic,
+                do_mode=True,  # 命令形は常に Do
             )
 
         # 「人物は関係ない」など直前の問いへの訂正・補足 → 受け止めて問いを変える
@@ -129,6 +208,7 @@ class SituationRouter:
             return SituationResult(
                 situation_type="correction",
                 resolved_topic=previous_topic,
+                do_mode=False,
             )
 
         topic_after_criticism = _extract_topic_after_criticism(text)
@@ -136,6 +216,7 @@ class SituationRouter:
             return SituationResult(
                 situation_type="criticism_then_topic",
                 resolved_topic=topic_after_criticism,
+                do_mode=do,
             )
 
         if _is_topic_switch(text):
@@ -146,28 +227,43 @@ class SituationRouter:
             return SituationResult(
                 situation_type="topic_switch",
                 resolved_topic=resolved or None,
+                do_mode=do,
             )
 
         if _is_vent_like(text):
-            return SituationResult(situation_type="vent", resolved_topic=None)
+            return SituationResult(
+                situation_type="vent",
+                resolved_topic=None,
+                do_mode=False,  # 感情吐き出しは常に Talk
+            )
 
         if _is_question(text):
-            return SituationResult(situation_type="question", resolved_topic=previous_topic)
+            return SituationResult(
+                situation_type="question",
+                resolved_topic=previous_topic,
+                do_mode=do,
+            )
 
-        # 「困っていない、一緒に考察しよう」など → 前の話題のまま、一緒に考える返答にする
+        # 「困っていない、一緒に考察しよう」など
         if _is_collaborative_or_rejecting_problem(text) and previous_topic:
             return SituationResult(
                 situation_type="same_topic_short",
                 resolved_topic=previous_topic,
+                do_mode=do,
             )
 
         if _same_topic_short(text, previous_topic):
             return SituationResult(
                 situation_type="same_topic_short",
                 resolved_topic=previous_topic,
+                do_mode=do,
             )
 
-        return SituationResult(situation_type="generic", resolved_topic=previous_topic)
+        return SituationResult(
+            situation_type="generic",
+            resolved_topic=previous_topic,
+            do_mode=do,
+        )
 
 
 situation_router = SituationRouter()

--- a/backend/app/workers/tasks.py
+++ b/backend/app/workers/tasks.py
@@ -362,11 +362,48 @@ def analyze_log_structure(self, log_id: str):
     return run_async(_analyze_structure())
 
 
+# ════════════════════════════════════════
+# 品質ゲート: Insight化する価値があるかの事前チェック
+# ════════════════════════════════════════
+_MIN_CONTENT_LENGTH = 30  # これ未満はInsight化しない
+_TRIVIAL_PATTERNS = {
+    "おはよう", "おやすみ", "ありがとう", "了解", "OK", "ok", "はい",
+    "テスト", "test", "あ", "うん", "そう", "なるほど",
+}
+
+
+def _check_insight_eligibility(log: RawLog) -> Optional[str]:
+    """
+    ログがInsight化に値するかチェックする。
+    不適格なら理由文字列を返す。適格なら None を返す。
+    """
+    content = (log.content or "").strip()
+
+    # 1. 短すぎるログ
+    if len(content) < _MIN_CONTENT_LENGTH:
+        return f"too_short ({len(content)} < {_MIN_CONTENT_LENGTH})"
+
+    # 2. STATE（状態記録）は知恵にならない
+    if log.intent and log.intent.value == "state":
+        return "intent_is_state"
+
+    # 3. 定型的・意味のない投稿
+    normalized = content.replace("。", "").replace("！", "").replace("？", "").strip()
+    if normalized in _TRIVIAL_PATTERNS:
+        return f"trivial_content: {normalized}"
+
+    # 4. 数字だけ・記号だけ
+    if re.fullmatch(r"[\d\s\W]+", content):
+        return "numeric_or_symbols_only"
+
+    return None
+
+
 @celery_app.task(bind=True, max_retries=3)
 def process_log_for_insight(self, log_id: str):
     """
     Layer 2: Gateway Refinery タスク
-    ログを匿名化 → 構造化 → 評価 → 保存
+    品質ゲート → 匿名化 → 構造化 → 評価 → 保存
     """
     async def _process():
         # Ensure engine connection pool is clean for this process/task
@@ -387,6 +424,16 @@ def process_log_for_insight(self, log_id: str):
                 logger.info(f"Log already processed for insight: {log_id}")
                 return {"status": "skipped", "message": "Already processed"}
 
+            # ── 品質ゲート: Insight化する価値があるかを事前チェック ──
+            skip_reason = _check_insight_eligibility(log)
+            if skip_reason:
+                log.is_processed_for_insight = True
+                await session.commit()
+                logger.info(
+                    f"Insight skipped (quality gate): log_id={log_id}, reason={skip_reason}"
+                )
+                return {"status": "skipped", "message": skip_reason}
+
             try:
                 logger.info(f"Starting insight processing for log_id: {log_id}")
                 # Step 1: Privacy Sanitizer - 匿名化
@@ -405,10 +452,30 @@ def process_log_for_insight(self, log_id: str):
                     }
                 )
 
+                # Step 2.5: Distiller が「知恵にならない」と判断した場合はスキップ
+                if distilled.get("not_suitable"):
+                    log.is_processed_for_insight = True
+                    await session.commit()
+                    logger.info(
+                        f"Insight skipped (distiller: not_suitable): log_id={log_id}"
+                    )
+                    return {"status": "skipped", "message": "not_suitable_for_wisdom"}
+
                 # Step 3: Sharing Broker - 評価
                 evaluation = await sharing_broker.evaluate_sharing_value(distilled)
 
-                # Step 4: InsightCard を作成
+                sharing_score = evaluation.get("sharing_value_score", 0)
+                should_propose = evaluation.get("should_propose", False)
+
+                # Step 4: ステータス判定
+                #   score >= 80 → 推奨（ユーザーに共有を提案）
+                #   score <  80 → 通常（保存のみ）
+                #   ※ 公開はユーザーの承認が必須。自動公開は行わない。
+                if should_propose:
+                    insight_status = InsightStatus.PENDING_APPROVAL
+                else:
+                    insight_status = InsightStatus.DRAFT
+
                 insight = InsightCard(
                     author_id=log.user_id,
                     source_log_id=log.id,
@@ -419,14 +486,10 @@ def process_log_for_insight(self, log_id: str):
                     summary=distilled.get("summary", ""),
                     topics=distilled.get("topics"),
                     tags=distilled.get("tags"),
-                    sharing_value_score=evaluation.get("sharing_value_score", 0),
+                    sharing_value_score=sharing_score,
                     novelty_score=evaluation.get("novelty_score", 0),
                     generality_score=evaluation.get("generality_score", 0),
-                    status=(
-                        InsightStatus.PENDING_APPROVAL
-                        if evaluation.get("should_propose", False)
-                        else InsightStatus.DRAFT
-                    ),
+                    status=insight_status,
                 )
 
                 session.add(insight)
@@ -438,12 +501,20 @@ def process_log_for_insight(self, log_id: str):
 
                 await session.refresh(insight)
 
+                promotion_type = "推奨" if should_propose else "通常"
+                logger.info(
+                    f"Insight pipeline complete: log_id={log_id}, "
+                    f"insight_id={insight.id}, score={sharing_score}, "
+                    f"type={promotion_type}"
+                )
+
                 return {
                     "status": "success",
                     "log_id": log_id,
                     "insight_id": str(insight.id),
-                    "should_propose": evaluation.get("should_propose", False),
-                    "sharing_value_score": evaluation.get("sharing_value_score", 0),
+                    "should_propose": should_propose,
+                    "sharing_value_score": sharing_score,
+                    "promotion_type": promotion_type,
                 }
 
             except Exception as e:

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -3,7 +3,7 @@
 /**
  * MINDYARD - Login Page
  */
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { api } from '@/lib/api';
@@ -11,11 +11,18 @@ import { useAuthStore } from '@/lib/store';
 
 export default function LoginPage() {
   const router = useRouter();
-  const { setUser } = useAuthStore();
+  const { isAuthenticated, setUser } = useAuthStore();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+
+  // 認証済みならトップページへリダイレクト
+  useEffect(() => {
+    if (isAuthenticated) {
+      router.replace('/');
+    }
+  }, [isAuthenticated, router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/app/proposals/page.tsx
+++ b/frontend/src/app/proposals/page.tsx
@@ -2,7 +2,7 @@
 
 /**
  * MINDYARD - Sharing Proposals Page
- * Layer 2: 共有提案の一覧と承認
+ * Layer 2: 推奨インサイトの一覧と承認
  */
 import { useState, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -76,9 +76,9 @@ export default function ProposalsPage() {
     <div className="max-w-3xl mx-auto px-4 py-8">
       {/* ヘッダー */}
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-800 mb-2">共有提案</h1>
+        <h1 className="text-2xl font-bold text-gray-800 mb-2">共有の推奨</h1>
         <p className="text-gray-500">
-          あなたの経験をチームに共有しませんか？
+          AIがあなたの知見に共有価値を見出しました。チームに共有しませんか？
         </p>
       </div>
 
@@ -94,9 +94,9 @@ export default function ProposalsPage() {
       ) : proposals?.length === 0 ? (
         <div className="text-center py-12">
           <Inbox className="w-12 h-12 text-gray-300 mx-auto mb-4" />
-          <p className="text-gray-500">現在、共有提案はありません</p>
+          <p className="text-gray-500">現在、推奨はありません</p>
           <p className="text-sm text-gray-400 mt-2">
-            記録を続けると、共有価値の高い知見が自動的に提案されます
+            記録を続けると、共有価値の高い知見がAIから推奨されます
           </p>
         </div>
       ) : (

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -3,7 +3,7 @@
 /**
  * MINDYARD - Register Page
  */
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { api } from '@/lib/api';
@@ -11,12 +11,19 @@ import { useAuthStore } from '@/lib/store';
 
 export default function RegisterPage() {
   const router = useRouter();
-  const { setUser } = useAuthStore();
+  const { isAuthenticated, setUser } = useAuthStore();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [displayName, setDisplayName] = useState('');
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+
+  // 認証済みならトップページへリダイレクト
+  useEffect(() => {
+    if (isAuthenticated) {
+      router.replace('/');
+    }
+  }, [isAuthenticated, router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -3,6 +3,7 @@
 /**
  * MINDYARD - Navigation Component
  */
+import { useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import {
@@ -15,10 +16,29 @@ import { useAuthStore, useNotificationStore } from '@/lib/store';
 import { api } from '@/lib/api';
 import { cn } from '@/lib/utils';
 
+const POLL_INTERVAL_MS = 30_000; // 30秒ごとに推奨インサイトをチェック
+
 export function Navigation() {
   const pathname = usePathname();
   const { user, isAuthenticated, logout } = useAuthStore();
-  const { pendingProposalCount } = useNotificationStore();
+  const { pendingProposalCount, setPendingProposalCount } = useNotificationStore();
+
+  // 推奨インサイトの件数をポーリング
+  const fetchPendingCount = useCallback(async () => {
+    if (!isAuthenticated) return;
+    try {
+      const proposals = await api.getPendingProposals();
+      setPendingProposalCount(proposals.length);
+    } catch {
+      // 認証切れなどは無視
+    }
+  }, [isAuthenticated, setPendingProposalCount]);
+
+  useEffect(() => {
+    fetchPendingCount(); // 初回チェック
+    const id = setInterval(fetchPendingCount, POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [fetchPendingCount]);
 
   const handleLogout = () => {
     api.logout();
@@ -40,7 +60,9 @@ export function Navigation() {
     },
   ];
 
-  if (!isAuthenticated) {
+  // 未認証 or 認証ページにいる場合はシンプルなナビを表示
+  const isAuthPage = pathname === '/login' || pathname === '/register';
+  if (!isAuthenticated || isAuthPage) {
     return (
       <nav className="fixed top-0 left-0 right-0 h-14 bg-white border-b border-gray-200 z-40">
         <div className="max-w-7xl mx-auto px-4 h-full flex items-center justify-between">

--- a/frontend/src/components/RecommendationPanel.tsx
+++ b/frontend/src/components/RecommendationPanel.tsx
@@ -4,11 +4,13 @@
  * MINDYARD - Recommendation Panel
  * Serendipity Matcher による「副作用的」レコメンデーション表示
  */
+import { useRouter } from 'next/navigation';
 import { X, Sparkles, ThumbsUp } from 'lucide-react';
 import { useRecommendationStore } from '@/lib/store';
 import { cn } from '@/lib/utils';
 
 export function RecommendationPanel() {
+  const router = useRouter();
   const { recommendations, isVisible, displayMessage, hideRecommendations } =
     useRecommendationStore();
 
@@ -71,7 +73,13 @@ export function RecommendationPanel() {
 
       {/* フッター */}
       <div className="p-2 bg-gray-50 border-t border-gray-100 text-center">
-        <button className="text-xs text-gray-500 hover:text-gray-700">
+        <button
+          onClick={() => {
+            hideRecommendations();
+            router.push('/proposals');
+          }}
+          className="text-xs text-gray-500 hover:text-gray-700"
+        >
           すべて見る
         </button>
       </div>

--- a/frontend/src/components/SharingProposalModal.tsx
+++ b/frontend/src/components/SharingProposalModal.tsx
@@ -2,7 +2,7 @@
 
 /**
  * MINDYARD - Sharing Proposal Modal
- * Layer 2: 共有提案の承認/拒否UI
+ * Layer 2: 推奨インサイトの承認/拒否UI
  */
 import { useState } from 'react';
 import { X, Share2, XCircle, Sparkles } from 'lucide-react';
@@ -44,7 +44,7 @@ export function SharingProposalModal({
         <div className="flex items-center justify-between p-4 border-b border-gray-200 bg-public-50">
           <div className="flex items-center gap-2 text-public-700">
             <Sparkles className="w-5 h-5" />
-            <span className="font-semibold">共有のご提案</span>
+            <span className="font-semibold">共有の推奨</span>
           </div>
           <button
             onClick={onClose}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -83,6 +83,7 @@ export interface RawLogListResponse {
 export interface AckResponse {
   message: string;
   log_id: string;
+  thread_id: string;  // スレッドID（次の送信で継続するために使用）
   timestamp: string;
   transcribed_text?: string;  // 音声入力時の文字起こしテキスト
   skip_structural_analysis?: boolean;
@@ -127,7 +128,7 @@ export interface SharingProposal {
 }
 
 // Conversation (LangGraph Hypothesis-Driven Routing)
-export type ConversationIntent = 'chat' | 'empathy' | 'knowledge' | 'deep_dive' | 'brainstorm' | 'probe';
+export type ConversationIntent = 'chat' | 'empathy' | 'knowledge' | 'deep_dive' | 'brainstorm' | 'probe' | 'state_share';
 
 export type PreviousEvaluation = 'positive' | 'negative' | 'pivot' | 'none';
 


### PR DESCRIPTION
## Summary
This PR introduces a dual-mode conversation system (Do/Talk) and integrates Layer 3 collective wisdom (Qdrant-based knowledge retrieval) into the conversation agent. It also adds quality gates for insight generation and improves authentication/session handling.

## Key Changes

### Conversation Agent Enhancements
- **Do/Talk Mode Switching**: Split system prompts into two distinct modes:
  - **Talk Mode** (`_TALK_SYSTEM_PROMPT`): Empathetic, collaborative thinking partner for exploration and discussion
  - **Do Mode** (`_DO_SYSTEM_PROMPT`): Action-oriented, results-focused partner for execution and implementation
- **Mode Detection**: `SituationRouter` now classifies user intent and sets `do_mode` flag based on imperative commands, action keywords, and execution-oriented language
- **Layer 3 Integration**: Conversation agent now searches Qdrant for related collective wisdom and injects relevant insights into system prompts naturally
- **Context Awareness**: Added `_summarize_recent_context()` to inject recent conversation history when user sends short utterances, preventing "what are you referring to?" responses

### Situation Router Improvements
- Added `imperative` situation type for command-like inputs ("create this", "do it")
- Added `do_mode` boolean flag to `SituationResult` dataclass
- Implemented `_is_imperative_command()` and `_is_do_intent()` detection functions
- Enhanced situation hints for imperative mode to guide execution-focused responses

### Insight Quality Gates
- **Pre-processing Quality Check** (`_check_insight_eligibility()`): Filters out trivial content (greetings, test posts, state-only logs) before processing
- **Distiller Enhancement**: Added `not_suitable` flag to detect and reject non-wisdom content (chatter, emotion-only venting, unanswered questions)
- **Stricter Evaluation**: Raised sharing threshold from 70 to 80 points; fallback evaluator now requires substantial solution content to reach recommendation threshold
- **Specificity Requirements**: Evaluation now checks for concrete details (tools, steps, numbers) rather than vague advice

### Thread History & Context Management
- **Dual-Level History Loading**: Conversation agent now tries same-thread history first, falls back to cross-thread recent logs if thread is new
- **Thread Continuation**: API now returns `thread_id` in `AckResponse` so frontend can maintain thread context across messages
- **Improved Fallback**: Prevents context loss when starting new threads by pulling recent conversation history

### Frontend Authentication & Session
- **Auth Guard**: Added `AuthGuard` component in providers to validate tokens on app startup and handle 401 responses
- **Token Validation**: Frontend now calls `getMe()` on mount to verify token validity; logs out if token is invalid
- **Unauthorized Handler**: API client now has `onUnauthorized()` callback to trigger Zustand logout on 401 responses
- **Login/Register Guards**: Added redirects to prevent authenticated users from accessing auth pages

### Backend Security
- **Boot Nonce**: Added random nonce generation on server startup (`_BOOT_NONCE`) that invalidates all previous tokens on container restart
- **Effective Secret**: JWT secret now includes boot nonce to ensure token rotation on deployment

### UI/UX Improvements
- **Timeline Thread Deletion**: Added delete button to timeline threads with confirmation dialog
- **Proposal Polling**: Navigation now polls for pending proposals every 30 seconds to keep badge count current
- **Thread Selection Logic**: Fixed `ThoughtStream` to only clear thread ID when explicitly deselecting from timeline (not on initial mount)
- **Recommendation Panel**: Added router integration for navigation from recommendations

### Database & API
- **LogIntent Enum**: Added `STATE` value to `LogIntent` enum for state-only logs (non-wisdom content)
- **Thread ID in Response**: `AckResponse` schema now includes `thread_id` for frontend thread continuation
- **Previous Topic Fallback**: Log creation endpoint now falls back to cross-thread recent logs when finding previous topic

## Notable Implementation Details
- Collective wisdom injection uses anonymous attribution ("チーム内で〜") to preserve privacy
- Do mode enforces "results first" format: conclusion → steps

https://claude.ai/code/session_01J7GyydU36Kf6YBQ3TZtb3M