### PR TITLE
Add Policy Weaver evaluation framework and Celery async testing guidelines

### DIFF
--- a/.claude/skills/plura-policy-weaver.md
+++ b/.claude/skills/plura-policy-weaver.md
@@ -20,3 +20,125 @@ ClaudeはPolicy Weaver関連の実装において、以下の原則を絶対に�
 
 ## 🛠️ 禁止事項
 - ユーザーのアクションを無条件で `BLOCK` するような静的バリデーションを初期実装から組み込むこと（常に `Suggest` か `Warn` から始める）。
+
+---
+
+## ⚖️ LLM-as-a-Judge 評価軸 (Evaluation Metrics)
+
+`PolicyEvaluator`（`BaseEvaluator` を継承）では、以下の3軸で1〜10点採点する。
+
+| 軸名 | 説明 | 合格閾値 |
+|------|------|---------|
+| `heuristic_compliance` | 二段階制度化の遵守: 出力ポリシーが絶対的な`BLOCK`ではなく、`Suggest`または`Warn`（Prompt as Code）として定義されているか。`enforcement_level` フィールドが `suggest` / `warn` のいずれかであれば高スコア。 | 7.0 |
+| `boundary_clarity` | 境界条件の明確さ: `applies_when` / `except_when` の条件が、入力の `dilemma_context` に記述されたジレンマを正確に反映しているか。曖昧・過度に広い条件は減点。 | 6.0 |
+| `ttl_appropriateness` | TTLの妥当性: `ttl_expires_at` が設定されており、ポリシーの性質に応じた合理的な再評価期限（例: 人事系なら6ヶ月、技術系なら3ヶ月）になっているか。未設定・遠すぎる日付は低スコア。 | 7.0 |
+
+### Golden Dataset JSONイメージ
+
+`backend/tests/golden_datasets/policy_weaver.json` の形式:
+
+```json
+{
+  "component": "PolicyWeaver",
+  "version": "1.0",
+  "description": "PolicyWeaverのルール抽出・構造化テストケース",
+  "cases": [
+    {
+      "id": "PW-001",
+      "input": {
+        "dilemma_context": "新メンバーが既存の設計ドキュメントを読まずにPRを出し続けている。指摘するとモチベーションが下がる可能性があるが、放置するとコード品質が低下する。",
+        "override_history": []
+      },
+      "expected": {
+        "expected_policy_structure": {
+          "principle": "新規参加者の自律性を尊重しつつ、チームの設計標準への段階的な誘導を優先する",
+          "enforcement_level": "suggest",
+          "applies_when": ["新メンバーが設計ドキュメントへの参照なしにPRを作成した場合"],
+          "except_when": ["緊急のバグ修正の場合", "メンバーが既存ドキュメントを参照した旨をPRに明記している場合"],
+          "ttl_expires_at": "6ヶ月以内の日付"
+        }
+      },
+      "tags": ["onboarding", "code_review", "gradual_guidance"],
+      "difficulty": "medium"
+    },
+    {
+      "id": "PW-002",
+      "input": {
+        "dilemma_context": "深夜にSlackで質問が来ることが多く、即答しないと翌日の作業がブロックされる。しかし対応を続けると自分が疲弊する。",
+        "override_history": [
+          {"reason": "緊急リリース前は対応せざるを得なかった"}
+        ]
+      },
+      "expected": {
+        "expected_policy_structure": {
+          "principle": "持続可能な応答習慣を維持し、深夜対応をデフォルト化しない",
+          "enforcement_level": "warn",
+          "applies_when": ["22時〜7時の時間帯にSlackへの即時返信が発生した場合"],
+          "except_when": ["本番障害など定義済みのインシデント対応プロセスが発動している場合"],
+          "ttl_expires_at": "3ヶ月以内の日付"
+        }
+      },
+      "tags": ["work_life_balance", "communication", "boundary"],
+      "difficulty": "hard"
+    }
+  ]
+}
+```
+
+### PolicyEvaluator 実装の骨格
+
+```python
+# tests/evaluators/policy_evaluator.py
+from typing import Dict, List
+from tests.evaluators.base_evaluator import BaseEvaluator
+
+
+class PolicyEvaluator(BaseEvaluator):
+    def __init__(self):
+        # heuristic_compliance と ttl_appropriateness の閾値が高め
+        super().__init__("PolicyWeaver", pass_threshold=6.5)
+
+    @property
+    def scoring_dimensions(self) -> List[Dict[str, str]]:
+        return [
+            {
+                "name": "heuristic_compliance",
+                "description": (
+                    "ポリシーの enforcement_level が 'suggest' または 'warn' であるか。"
+                    "'block' や強制停止ロジックが含まれていれば低スコア。"
+                ),
+            },
+            {
+                "name": "boundary_clarity",
+                "description": (
+                    "applies_when / except_when の条件が入力ジレンマを正確に反映しているか。"
+                    "過度に曖昧な条件や、ジレンマと無関係な条件は減点。"
+                ),
+            },
+            {
+                "name": "ttl_appropriateness",
+                "description": (
+                    "ttl_expires_at が設定されており、ポリシー内容に対して合理的な期限か。"
+                    "未設定・無期限・過度に遠い日付は低スコア。"
+                ),
+            },
+        ]
+
+    async def run_component(self, input_data: Dict) -> Dict:
+        # Celeryタスクとして実装されているため、テスト時は同期的に呼び出す
+        # plura-self-optimization.md §3.3 末尾のCelery非同期テスト指針を参照
+        from app.services.layer3.policy_weaver import policy_weaver
+        result = await policy_weaver.extract_policy(
+            dilemma_context=input_data["dilemma_context"],
+            override_history=input_data.get("override_history", []),
+        )
+        return result
+
+    def build_judge_prompt(self, input_data: Dict, output: Dict, expected: Dict) -> str:
+        return (
+            f"## ジレンマの文脈\n{input_data['dilemma_context']}\n\n"
+            f"## 抽出されたポリシー\n{output}\n\n"
+            f"## 期待されるポリシー構造\n{expected.get('expected_policy_structure', '指定なし')}\n\n"
+            "上記のポリシー抽出結果を評価してください。"
+        )
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,14 @@
 `.claude/skills/plura-self-optimization.md` を参照すること。
 ```
 
+### Policy Weaver（ルール抽出・制度化・TTL設計）
+Policy Weaver の実装・修正時は `.claude/skills/plura-policy-weaver.md` を参照すること。
+ルールの抽出・制度化・TTL設計に関する制約（二段階制度化、TTL必須、Override歓迎）が定義されている。
+
+### 非同期タスク（Celery キュー分離）
+非同期タスクを実装する際は `.claude/skills/plura-async-architecture.md` を参照すること。
+`fast_queue` / `heavy_queue` の分離原則が定義されている。Policy Weaverは `heavy_queue` 必須。
+
 ### 3. 確認
 
 Claude Code で以下のように指示して、スキルが認識されることを確認：
@@ -64,6 +72,22 @@ PII除去率・文脈維持率・自然さの3軸で採点するように。
 ```
 IntentRouter の失敗ケースを分析して改善案を出して。
 SKILL.md の Section 5 の prompt_optimizer パターンで。
+```
+
+### Phase 4: Policy Weaverの評価実装
+
+```
+Policy WeaverのGolden Datasetを作成して。
+ジレンマと境界条件が抽出できているかを評価軸にして。
+plura-policy-weaver.md の golden_dataset イメージに従い、
+dilemma_context と expected_policy_structure を含む形式で。
+```
+
+```
+PolicyEvaluator を実装して。
+plura-policy-weaver.md の評価軸（heuristic_compliance / boundary_clarity / ttl_appropriateness）を使って、
+plura-self-optimization.md の BaseEvaluator を継承し3軸採点するように。
+Celeryタスクのテストは plura-self-optimization.md §3.3 末尾の非同期タスクテスト指針に従うこと。
 ```
 
 ---


### PR DESCRIPTION
## Summary
This PR introduces the Policy Weaver evaluation framework with LLM-as-a-Judge scoring metrics, golden dataset structure, and implementation guidelines. It also documents best practices for testing Celery async tasks.

## Key Changes

### Policy Weaver Evaluation Framework
- **Added 3-axis evaluation metrics** in `plura-policy-weaver.md`:
  - `heuristic_compliance` (threshold: 7.0): Validates that policies use `suggest`/`warn` enforcement levels, not absolute `BLOCK`
  - `boundary_clarity` (threshold: 6.0): Ensures `applies_when`/`except_when` conditions accurately reflect input dilemmas
  - `ttl_appropriateness` (threshold: 7.0): Verifies TTL expiration dates are set with reasonable re-evaluation periods

- **Defined golden dataset JSON structure** with two representative test cases:
  - `PW-001`: Onboarding dilemma (new member PR review guidance)
  - `PW-002`: Work-life balance dilemma (deep night Slack response expectations)
  - Each case includes dilemma context, override history, expected policy structure, and difficulty tags

- **Provided `PolicyEvaluator` implementation skeleton** that:
  - Extends `BaseEvaluator` with pass threshold of 6.5
  - Implements three scoring dimensions with detailed descriptions
  - Includes `build_judge_prompt()` for LLM evaluation
  - Calls `policy_weaver.extract_policy()` as the component under test

### Celery Async Testing Guidelines
- **Added best practices section** in `plura-self-optimization.md` (§3.3 supplement):
  - Recommends testing Celery task core logic directly via async functions (preferred approach)
  - Documents task dispatch mocking for integration tests
  - Explicitly discourages `CELERY_TASK_ALWAYS_EAGER = True` pattern

### Documentation Updates
- **Updated `CLAUDE.md`** with new skill references:
  - Added Policy Weaver skill reference with constraint summary
  - Added Celery async architecture skill reference
  - Added Phase 4 prompt examples for Policy Weaver golden dataset and evaluator implementation

- **Updated component registry** in `plura-self-optimization.md`:
  - Added `PolicyWeaver` entry with `heavy_queue` designation and evaluation focus areas

## Implementation Details

The evaluation framework enforces the two-stage policy design principle: policies must start with `Suggest` or `Warn` guidance rather than hard `BLOCK` enforcement. The TTL requirement ensures policies are periodically re-evaluated rather than becoming static rules.

The golden dataset format supports both simple and complex dilemmas with override history tracking, enabling evaluation of how the system handles policy exceptions and historical context.

https://claude.ai/code/session_01K4ByNLgn8b9XEA2hvnCakq